### PR TITLE
Increment supported FunctionZeros version

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hankel"
 uuid = "74863788-d124-456e-a676-9b76578dd39e"
 authors = ["chrisbrahms <38351086+chrisbrahms@users.noreply.github.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
@@ -11,6 +11,6 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ChainRulesCore = "0.7, 0.8, 0.9"
-FunctionZeros = "0.1"
+FunctionZeros = "0.1, 0.2"
 SpecialFunctions = "0.10"
 julia = "1"


### PR DESCRIPTION
As pointed out by @antoine-levitt in https://github.com/JuliaMolSim/DFTK.jl/pull/399#issuecomment-765219106, we bound to an old FunctionZeros version. This PR fixes that.