### PR TITLE
Speed up calculation of zeros

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "Hankel"
 uuid = "74863788-d124-456e-a676-9b76578dd39e"
 authors = ["chrisbrahms <38351086+chrisbrahms@users.noreply.github.com>"]
-version = "0.5.3"
+version = "0.5.4"
 
 [deps]
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -181,8 +181,8 @@ end
 
 Get the ``n``th zero of the Bessel function of order ``\\nu``.
 """
-function besselj_zero(nu, n; order=2)
-    return Roots.fzero(x -> besselj(nu, x), besselj_zero_init(nu, n); order=order)
+function besselj_zero(nu, n)
+    return Roots.find_zero(x -> besselj(nu, x), besselj_zero_init(nu, n), Roots.Order2())
 end
 
 """


### PR DESCRIPTION
Roots.jl has two interfaces for computing zeros that behave slightly differently. This PR adopts the other interface. I tested for a wide range of values, and this implementation is 1.5x to 4.5x faster than the one we were using before and the resulting zeros are approximately equal.