### PR TITLE
Expand ChainRules

### DIFF
--- a/src/Hankel.jl
+++ b/src/Hankel.jl
@@ -2,7 +2,8 @@ module Hankel
 import SpecialFunctions: besselj, gamma
 using GSL: GSL
 using Roots: Roots
-import LinearAlgebra: mul!, ldiv!, dot
+import LinearAlgebra: mul!, ldiv!
+using LinearAlgebra: axpy!, dot
 import Base: *, \
 using ChainRulesCore
 

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -84,9 +84,8 @@ Calculate the dot product between vector `v` and one dimension of array `A`, ite
 all other dimensions.
 """
 function dimdot(v, A; dim=1)
-    dims = collect(size(A))
-    dims[dim] = 1
-    out = Array{eltype(A)}(undef, Tuple(dims))
+    dims = Base.setindex(size(A), 1, dim)
+    out = zeros(eltype(A), dims)
     dimdot!(out, v, A; dim=dim)
     return out
 end
@@ -104,7 +103,7 @@ end
 function _dimdot!(out, v, A, idxlo, idxhi)
     for lo in idxlo
         for hi in idxhi
-            out[lo, 1, hi] = dot(v, view(A, lo, :, hi))
+            out[lo, 1, hi] += dot(v, view(A, lo, :, hi))
         end
     end
 end

--- a/test/chainrules.jl
+++ b/test/chainrules.jl
@@ -26,88 +26,76 @@
         end
     end
 
-    @testset "$f(::QDHT, ::Array{<:Real})" for f in (*, \)
+    @testset "$f" for f in (*, \)
         rng = MersenneTwister(86)
         N, M, K = 64, 5, 10
-        @testset "Vector" begin
-            q = Hankel.QDHT{1,2}(10, N)
+        @testset "$f(::QDHT, ::Vector{$T})" for T in (Float64,)
+            q = Hankel.QDHT{1,2}(10.0, N)
             fr = randn(rng, N)
-            test_rrule(f, q ⊢ NoTangent(), fr)
-            test_frule(f, q ⊢ NoTangent(), fr)
+            test_rrule(f, q, fr)
         end
 
-        @testset "Matrix" begin
-            @testset for dim in (1, 2)
-                q = Hankel.QDHT{1,2}(10, N; dim = dim)
-                s = dim == 1 ? (N, M) : (M, N)
-                fr = randn(rng, s)
-                test_rrule(f, q ⊢ NoTangent(), fr)
-                test_frule(f, q ⊢ NoTangent(), fr)
-            end
+        @testset "$f(::QDHT, ::Matrix{$T}; dim=$dim)" for T in (Float64,), dim in (1, 2)
+            q = Hankel.QDHT{1,2}(10.0, N; dim = dim)
+            s = dim == 1 ? (N, M) : (M, N)
+            fr = randn(rng, T, s)
+            test_rrule(f, q, fr)
         end
 
-        @testset "Array{<:Real,3}" begin
-            q = Hankel.QDHT{1,2}(10, N; dim = 2)
-            s = (M, N, K)
+        @testset "$f(::QDHT, ::Array{$T,3}; dim=$dim)" for T in (Float64,), dim in (1, 2, 3)
+            q = Hankel.QDHT{1,2}(10.0, N; dim = dim)
+            s = dim == 1 ? (N, M, K) : (dim == 2 ? (M, N, K) : (M, K, N))
             fr = randn(rng, s)
-            test_rrule(f, q ⊢ NoTangent(), fr)
-            test_frule(f, q ⊢ NoTangent(), fr)
+            test_rrule(f, q, fr)
         end
     end
 
-    @testset "$f(::Array{<:Real}, ::QDHT, ::Array{<:Real})" for f in (mul!, ldiv!)
+    @testset "$f" for f in (mul!, ldiv!)
         rng = MersenneTwister(86)
         N, M, K = 64, 5, 10
-        @testset "Vector" begin
-            q = Hankel.QDHT{1,2}(10, N)
-            fr, fk = ntuple(_ -> randn(rng, N), 2)
-            test_frule(f, fk, q ⊢ NoTangent(), fr)
+        @testset "$f(::Vector{$T}, ::QDHT, ::Vector{$T})" for T in (Float64,)
+            q = Hankel.QDHT{1,2}(10.0, N)
+            fr, fk = ntuple(_ -> randn(rng, T, N), 2)
+            test_frule(f, fk, q, fr)
         end
 
-        @testset "Matrix" begin
-            @testset for dim in (1, 2)
-                q = Hankel.QDHT{1,2}(10, N; dim = dim)
-                s = dim == 1 ? (N, M) : (M, N)
-                fr, fk = ntuple(_ -> randn(rng, s), 2)
-                test_frule(f, fk, q ⊢ NoTangent(), fr)
-            end
+        @testset "$f(::Matrix{$T}, ::QDHT, ::Matrix{$T})" for T in (Float64,), dim in (1, 2)
+            q = Hankel.QDHT{1,2}(10.0, N; dim = dim)
+            s = dim == 1 ? (N, M) : (M, N)
+            fr, fk = ntuple(_ -> randn(rng, T, s), 2)
+            test_frule(f, fk, q, fr)
         end
 
-        @testset "Array{<:Real,3}" begin
-            q = Hankel.QDHT{1,2}(10, N; dim = 2)
-            s = (M, N, K)
-            fr, fk = ntuple(_ -> randn(rng, s), 2)
-            test_frule(f, fk, q ⊢ NoTangent(), fr)
+        @testset "$f(::Array{$T,3}, ::QDHT, ::Array{$T,3})" for T in (Float64,), dim in (1, 2, 3)
+            q = Hankel.QDHT{1,2}(10.0, N; dim = dim)
+            s = dim == 1 ? (N, M, K) : (dim == 2 ? (M, N, K) : (M, K, N))
+            fr, fk = ntuple(_ -> randn(rng, T, s), 2)
+            test_frule(f, fk, q, fr)
         end
     end
 
-    @testset "$f(::Array{<:Real}, ::QDHT)" for f in (integrateR, integrateK)
+    @testset "dimdot" begin
         rng = MersenneTwister(27)
         N, M, K = 64, 5, 10
-        q = Hankel.QDHT{1,2}(10, N)
-        @testset "Vector" begin
-            A = randn(rng, N)
-            test_rrule(f, A, q ⊢ NoTangent())
-            test_frule(f, A, q ⊢ NoTangent())
+        v = randn(rng, N)
+        @testset "dimdot(v, A::Vector{$T})" for T in (Float64,)
+            A = randn(rng, T, N)
+            test_rrule(Hankel.dimdot, v, A; fkwargs = (dim = 1,))
+            test_frule(Hankel.dimdot, v, A; fkwargs = (dim = 1,))
         end
 
-        @testset "Matrix" begin
-            @testset for dim in (1, 2)
-                s = dim == 1 ? (N, M) : (M, N)
-                sy = dim == 1 ? (1, M) : (M, 1)
-                A = randn(rng, s)
-                test_rrule(f, A, q ⊢ NoTangent(); fkwargs = (dim = dim,))
-                test_frule(f, A, q ⊢ NoTangent(); fkwargs = (dim = dim,))
-            end
+        @testset "dimdot(v, A::Matrix{$T}; dim=$dim)" for T in (Float64,), dim in (1, 2)
+            s = dim == 1 ? (N, M) : (M, N)
+            A = randn(rng, T, s)
+            test_rrule(Hankel.dimdot, v, A; fkwargs = (dim = dim,))
+            test_frule(Hankel.dimdot, v, A; fkwargs = (dim = dim,))
         end
 
-        @testset "Array{<:Real,3}" begin
-            s = (M, N, K)
-            sy = (M, 1, K)
-            dim = 2
-            A = randn(rng, s)
-            test_rrule(f, A, q ⊢ NoTangent(); fkwargs = (dim = dim,))
-            test_frule(f, A, q ⊢ NoTangent(); fkwargs = (dim = dim,))
+        @testset "dimdot(v, A::Array{$T,3}; dim=$dim)" for T in (Float64,), dim in (1, 2, 3)
+            s = dim == 1 ? (N, M, K) : (dim == 2 ? (M, N, K) : (M, K, N))
+            A = randn(rng, T, s)
+            test_rrule(Hankel.dimdot, v, A; fkwargs = (dim = dim,))
+            test_frule(Hankel.dimdot, v, A; fkwargs = (dim = dim,))
         end
     end
 end


### PR DESCRIPTION
After #27, I set about marking derivatives wrt `QDHT` as `NotImplemented` instead of non-differentiable, but I realized it actually wouldn't be too hard to make the rules differentiable wrt `QDHT`, which could be useful if one wants to optimize `R`. This PR does that, as well as making a few other improvements to the rules.